### PR TITLE
Add Richard Lau to post-mortem WG

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,5 @@ The members of the working group include:
   + Luca Maraschi (@lucamaraschi)
   + David Mark Clements (@davidmarkclem)
   + Richard Chamberlain (@rnchamberlain)
+  + Richard Lau (@richardlau)
   + any others interested from the community


### PR DESCRIPTION
PR for discussion about adding Richard Lau (@richardlau) to the post-mortem Workgroup.

He has been active in contributing to nodereport (https://github.com/nodejs/nodereport/graphs/contributors) both by reviewing and contributing pull requests so I think think makes sense.